### PR TITLE
ci(workflows): 重构用户脚本构建与发布流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,50 @@
-name: Build
+name: Build Userscript
 
 on:
-  push:
-    branches: [dev, main]
-  pull_request:
   workflow_dispatch:
+
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "rollup.config.*"
+      - "tsconfig.json"
+      - ".github/workflows/build.yml"
+
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "rollup.config.*"
+      - "tsconfig.json"
+      - ".github/workflows/build.yml"
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    if: |
+      !contains(github.event.head_commit.message || '', '[skip build]')
+
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -25,33 +52,30 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Inject version for dev build
-        if: github.ref_name == 'dev'
-        id: inject
-        run: |
-          BASE_VERSION=$(node -p "require('./package.json').version")
-
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          FULL_VERSION="${BASE_VERSION}-dev+${SHORT_SHA}"
-
-          sed -i -E "s|//[[:space:]]*@version[[:space:]]+.*|// @version      ${FULL_VERSION}|" dist/EdgeDL.user.js
-
-          echo "full_version=${FULL_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Resolve artifact name
+      - name: Prepare artifact file
         id: artifact
         run: |
-          if [ -n "${{ steps.inject.outputs.full_version }}" ]; then
-            VERSION="${{ steps.inject.outputs.full_version }}"
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+
+          if [ "${GITHUB_REF_NAME}" = "main" ] && [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            VERSION="${BASE_VERSION}"
           else
-            VERSION=$(node -p "require('./package.json').version")
+            VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
           fi
 
-          NAME="EdgeDL-build-${VERSION}"
-          echo "name=$NAME" >> $GITHUB_OUTPUT
+          sed -i -E "s|//[[:space:]]*@version[[:space:]]+.*|// @version      ${VERSION}|" dist/EdgeDL.user.js
 
-      - name: Upload build artifact
+          FILE="dist/EdgeDL-v${VERSION}.user.js"
+          cp dist/EdgeDL.user.js "$FILE"
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "path=${FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload userscript artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.artifact.outputs.name }}
-          path: dist/EdgeDL.user.js
+          path: ${{ steps.artifact.outputs.path }}
+          archive: false
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,24 +1,25 @@
-name: Release Userscript
+name: Preview Release Userscript
 
 on:
   push:
     branches:
-      - main
+      - dev
     paths:
       - "src/**"
       - "package.json"
       - "package-lock.json"
       - "rollup.config.*"
       - "tsconfig.json"
-      - ".github/workflows/release.yml"
+      - ".github/workflows/preview-release.yml"
 
 permissions:
   contents: write
 
 jobs:
-  release:
+  preview_release:
     if: |
-      startsWith(github.event.head_commit.message, 'chore(release): v') &&
+      contains(github.event.head_commit.message, '[release]') &&
+      !contains(github.event.head_commit.message, '[skip preview]') &&
       !contains(github.event.head_commit.message, '[skip release]')
 
     runs-on: ubuntu-latest
@@ -42,25 +43,13 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Prepare release asset
+      - name: Prepare preview asset
         id: asset
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
           TAG="v${VERSION}"
-          EXPECTED_SUBJECT="chore(release): ${TAG}"
-          COMMIT_SUBJECT=$(git log -1 --pretty=%s)
-
-          if [ "$COMMIT_SUBJECT" != "$EXPECTED_SUBJECT" ]; then
-            echo "Release commit subject mismatch."
-            echo "Expected: $EXPECTED_SUBJECT"
-            echo "Actual:   $COMMIT_SUBJECT"
-            exit 1
-          fi
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists."
-            exit 1
-          fi
 
           sed -i -E "s|//[[:space:]]*@version[[:space:]]+.*|// @version      ${VERSION}|" dist/EdgeDL.user.js
 
@@ -71,7 +60,19 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "path=${FILE}" >> "$GITHUB_OUTPUT"
 
+      - name: Check existing preview tag
+        id: tag
+        run: |
+          TAG="${{ steps.asset.outputs.tag }}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate changelog
+        if: steps.tag.outputs.exists != 'true'
         run: |
           PREV_TAG=$(git tag --list "v[0-9]*.[0-9]*.[0-9]*" | grep -Ev "dev|beta|alpha|rc" | sort -V | tail -n 1)
 
@@ -91,7 +92,8 @@ jobs:
             echo "No changelog entries." > RELEASE_NOTES.md
           fi
 
-      - name: Create release
+      - name: Create preview release
+        if: steps.tag.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -99,4 +101,10 @@ jobs:
             "${{ steps.asset.outputs.path }}" \
             --title "${{ steps.asset.outputs.tag }}" \
             --notes-file RELEASE_NOTES.md \
-            --target "$GITHUB_SHA"
+            --target "$GITHUB_SHA" \
+            --prerelease
+
+      - name: Skip existing preview release
+        if: steps.tag.outputs.exists == 'true'
+        run: |
+          echo "Tag ${{ steps.asset.outputs.tag }} already exists. Skipping preview release."

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,6 +1,8 @@
 name: Preview Release Userscript
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - dev
@@ -18,9 +20,11 @@ permissions:
 jobs:
   preview_release:
     if: |
-      contains(github.event.head_commit.message, '[release]') &&
-      !contains(github.event.head_commit.message, '[skip preview]') &&
-      !contains(github.event.head_commit.message, '[skip release]')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.head_commit.message, '[release]') &&
+        !contains(github.event.head_commit.message, '[skip release]')
+      )
 
     runs-on: ubuntu-latest
 
@@ -75,22 +79,80 @@ jobs:
         if: steps.tag.outputs.exists != 'true'
         run: |
           PREV_TAG=$(git tag --list "v[0-9]*.[0-9]*.[0-9]*" | grep -Ev "dev|beta|alpha|rc" | sort -V | tail -n 1)
+          CURR_TAG="${{ steps.asset.outputs.tag }}"
+          VERSION="${{ steps.asset.outputs.version }}"
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          CHANGES_FILE=$(mktemp)
+          COMMITS_FILE=$(mktemp)
 
           if [ -n "$PREV_TAG" ]; then
-            npx -y conventional-changelog-cli -p angular \
-              --from "$PREV_TAG" \
-              --to HEAD \
-              --tag-prefix v \
-              > RELEASE_NOTES.md
+            LOG_RANGE="$PREV_TAG..HEAD"
+            BASE_LABEL="$PREV_TAG"
+            COMPARE_RANGE="${PREV_TAG}...${CURR_TAG}"
+            COMPARE_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${COMPARE_RANGE}"
           else
-            npx -y conventional-changelog-cli -p angular \
-              --tag-prefix v \
-              > RELEASE_NOTES.md
+            LOG_RANGE="HEAD"
+            BASE_LABEL="None"
+            COMPARE_RANGE="${CURR_TAG}"
+            COMPARE_URL="https://github.com/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}"
           fi
 
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "No changelog entries." > RELEASE_NOTES.md
+          git log "$LOG_RANGE" --pretty=format:"%s" > "$COMMITS_FILE" || true
+
+          while IFS= read -r subject || [ -n "$subject" ]; do
+            case "$subject" in
+              Merge*) continue ;;
+            esac
+
+          title=$(printf '%s' "$subject" | sed -E 's/[[:space:]]*\[release\].*$//')
+            [ -z "$title" ] && continue
+
+            type=$(printf '%s' "$title" | sed -nE 's/^([a-z]+)(\([^)]+\))?(!)?:[[:space:]]+.*/\1/p')
+            text=$(printf '%s' "$title" | sed -E 's/^[a-z]+(\([^)]+\))?(!)?:[[:space:]]+//')
+            [ -z "$type" ] && type="other"
+
+            printf '%s\t%s\n' "$type" "$text" >> "$CHANGES_FILE"
+          done < "$COMMITS_FILE"
+
+          {
+            echo "## EdgeDL v${VERSION}"
+            echo ""
+            echo "**Channel:** Preview  "
+            echo "**Commit:** \`${SHORT_SHA}\`  "
+            echo "**Base:** \`${BASE_LABEL}\`"
+            echo ""
+            echo "## Changelog"
+          } > RELEASE_NOTES.md
+
+          append_group() {
+            type="$1"
+            heading="$2"
+            items=$(awk -F '\t' -v type="$type" '$1 == type { print "- " $2 }' "$CHANGES_FILE")
+            [ -z "$items" ] && return
+
+            echo "" >> RELEASE_NOTES.md
+            echo "### $heading" >> RELEASE_NOTES.md
+            printf '%s\n' "$items" >> RELEASE_NOTES.md
+          }
+
+          append_group feat "Features"
+          append_group fix "Bug Fixes"
+          append_group perf "Performance"
+          append_group refactor "Refactoring"
+          append_group docs "Documentation"
+          append_group style "Styles"
+          append_group ci "CI"
+          append_group test "Tests"
+          append_group chore "Chores"
+          append_group other "Other Changes"
+
+          if ! grep -q '^### ' RELEASE_NOTES.md; then
+            echo "" >> RELEASE_NOTES.md
+            echo "No preview changes found." >> RELEASE_NOTES.md
           fi
+
+          echo "" >> RELEASE_NOTES.md
+          echo "**Full Changelog:** [\`${COMPARE_RANGE}\`](${COMPARE_URL})" >> RELEASE_NOTES.md
 
       - name: Create preview release
         if: steps.tag.outputs.exists != 'true'


### PR DESCRIPTION
## Summary

本次 PR 重构 EdgeDL 的 GitHub Actions 构建与发布流程，拆分普通构建、预发布和正式发布逻辑，并优化预发布 Release Notes 的生成方式。

## Changes

### Build Workflow

- 将工作流名称调整为 `Build Userscript`
- 为 `push` / `pull_request` 增加路径过滤，减少无关文件变更触发 CI
- 统一构建产物命名为：
  - `EdgeDL-vX.Y.Z.user.js`
  - `EdgeDL-vX.Y.Z-dev.<sha>.user.js`
- 构建时同步注入 userscript 内部 `@version`
- 使用 `actions/upload-artifact@v7` 的 `archive: false` 上传未压缩 `.user.js` 产物
- 增加 artifact 保留时间配置

### Preview Release Workflow

- 新增 `Preview Release Userscript` 工作流
- 支持 `dev` 分支通过提交信息中的 `[release]` 触发预发布
- 支持手动运行 workflow 创建 prerelease
- 自动生成 `vX.Y.Z-dev.<sha>` 形式的预发布 tag
- 构建并上传对应的 `.user.js` Release Asset
- 优化预发布更新日志生成：
  - 输出版本、Channel、Commit、Base 信息
  - 按 Conventional Commit 类型分组展示变更
  - 自动生成 Full Changelog 链接

### Release Workflow

- 将正式发布流程简化为仅处理 `main` 分支 release commit
- 使用 `chore(release): vX.Y.Z` 作为正式发布触发条件
- 移除旧的 beta 版本递增逻辑、提交数量判断和 Release Summary
- 统一正式版产物命名为 `EdgeDL-vX.Y.Z.user.js`
- 使用 GitHub CLI 创建正式 Release

## Notes

- 普通构建和发布流程已拆分，避免 release workflow 承担 dev/prerelease 的复杂判断
- Release Notes 保持自动生成，不额外添加人工说明